### PR TITLE
Fix Java util logging not generate log message correctly

### DIFF
--- a/LogSimulator.groovy
+++ b/LogSimulator.groovy
@@ -855,7 +855,7 @@ public class LogGenerator
                             if (verbose) {System.out.println ("about to fire Java Util Logging ("+toJULLevel(log.logLevel, props)+") " + log.message);}
                             try 
                             {
-                                juLogger.log (toJULLevel(log.logLevel, props), log.location,"", output);
+                                juLogger.logp (toJULLevel(log.logLevel, props), log.location,"", output);
                             }
                             catch (Exception err)
                             {


### PR DESCRIPTION
Hi Phil,

I found that log generate using JUL in Logging in Action Chapter3 not correctly generated

Nont
